### PR TITLE
Change to alpine docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache add \
     python \
   && pip install streamlink \
   && pip install pycryptodome \
-  && apk del build-base
+  && apk --no-cache del build-base
 
 WORKDIR /app/
 COPY package.json /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,19 @@
-FROM ubuntu:17.10
+FROM node:alpine
 
-# install node
-RUN apt-get update
-RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get install -y nodejs
+RUN apk --no-cache add \
+    build-base \
+    ffmpeg \
+    py-pip \
+    python \
+  && pip install streamlink \
+  && pip install pycryptodome \
+  && apk del build-base
 
-# install yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
-
-# install streamlink
-RUN apt-get install -y python-pip
-RUN pip install streamlink
-RUN pip install pycryptodome
-
-# install ffmpeg
-RUN apt-get install -y ffmpeg
-
-RUN mkdir /usr/src/app
-WORKDIR /usr/src/app/
-
-# Install dependencies
-COPY package.json /usr/src/app/
-COPY yarn.lock /usr/src/app/
+WORKDIR /app/
+COPY package.json /app/
+COPY yarn.lock /app/
 RUN yarn install
 
-ADD . /usr/src/app/
+COPY . /app/
 
 CMD [ "yarn", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ RUN yarn install
 COPY . /app/
 
 CMD [ "yarn", "start" ]
+USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,15 @@ services:
     stdin_open: true
     tty: true
     build: .
-    working_dir: /usr/src/app
+    working_dir: /app
     env_file:
       - .env
     volumes:
-      - .:/usr/src/app
+      - .:/app
       # logs, session data
-      - ./tmp:/usr/src/app/tmp
-      - ${DOWNLOAD_DIR}:/usr/src/app/video
-      - node_modules:/usr/src/app/node_modules
+      - ./tmp:/app/tmp
+      - ${DOWNLOAD_DIR}:/app/video
+      - node_modules:/app/node_modules
 
 volumes:
   node_modules:


### PR DESCRIPTION
This reduces the size of the image from 903MB down to 283MB, and builds significantly faster

Notes:
This will use the latest Node.js version (9.4 at time of writing). You might want to change the base image (e.g. to node:alpine-8) if this is undesirable.
This also switches to using /app as the default folder within the container rather than /usr/src/app as it's defined by default in the node container and doesn't need to be created prior to use.