### PR TITLE
Use python3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM node:10.11-alpine
 RUN apk --no-cache add \
     build-base \
     ffmpeg \
-    py-pip \
+    python3 \
     python-dev \
     libffi-dev \
     openssl-dev \
-  && pip install streamlink \
-  && pip install pycryptodome \
+  && pip3 install streamlink \
+  && pip3 install pycryptodome \
   && apk --no-cache del build-base
 
 WORKDIR /app/


### PR DESCRIPTION
The Dockerfile is failing to build with python2 with the error: "No
matching distribution found for cffi!=1.11.3,>=1.7".  Switching to
python3 should provide much more reliable dependency fulfillments.