### PR TITLE
get nhltv to work again

### DIFF
--- a/src/geekyStreamsApi.ts
+++ b/src/geekyStreamsApi.ts
@@ -10,6 +10,8 @@ import {
   GAME_DETAILED_STATE,
 } from "./nhlStatsApi";
 
+export const HttpUserAgent = 'nhltv/0.27.2';
+
 export interface Config {
   emailNhltv: string;
   passwordNhltv: string;
@@ -245,10 +247,29 @@ export const idPathVariableInterceptor = (config: AxiosRequestConfig): AxiosRequ
 
 export const timeXhrFetch = async (url: string, config?: AxiosRequestConfig): Promise<AxiosResponse> => {
   const start = new Date();
-  if (enableLogTimings) console.log('beginFetch', url, start);
+
+  if (!config) {
+    config = {};
+  }
+
+  const defaultHeaders = {
+    'User-Agent': HttpUserAgent,
+  };
+  config.headers = {...config.headers, ...defaultHeaders};
+
+  if (enableLogTimings) {
+    console.log('beginFetch', url, "params:", config.params, "request-headers:", config.headers, start);
+  }
+
   const result = await axios.get(url, config);
   const end = new Date();
-  if (enableLogTimings) console.log('endFetch', url, end, luxon.DateTime.fromJSDate(end).diff(luxon.DateTime.fromJSDate(start)).toMillis());
+
+  if (enableLogTimings) {
+    console.log('endFetch', url, "status:", result.status, end, "ms:", luxon.DateTime.fromJSDate(end).diff(luxon.DateTime.fromJSDate(start)).toMillis());
+    console.log('result-headers:', result.headers);
+    console.log('');
+  }
+
   return result;
 }
 
@@ -285,10 +306,25 @@ export const timeXhrRequest = async <TAPI extends RestypedBase, TPath extends Ex
   config: TypedAxiosRequestConfig<TAPI, TPath, TMethod>
 ): Promise<TypedAxiosResponse<TAPI, TPath, TMethod>> => {
   const start = new Date();
-  if (enableLogTimings) console.log('beginRequest', config.url, start);
+
+  const defaultHeaders = {
+    'User-Agent': HttpUserAgent,
+  };
+  config.headers = {...config.headers, ...defaultHeaders};
+
+  if (enableLogTimings) {
+    console.log('beginRequest', config.method, config.url, '['+axiosInstance.defaults.baseURL+']', "params:", config.params, "request-headers:", config.headers, start);
+  }
+
   const result = await axiosInstance.request(config);
   const end = new Date();
-  if (enableLogTimings) console.log('endRequest', config.url, end, luxon.DateTime.fromJSDate(end).diff(luxon.DateTime.fromJSDate(start)).toMillis());
+
+  if (enableLogTimings) {
+    console.log('endRequest', config.url, "status:", result.status, end, "ms:", luxon.DateTime.fromJSDate(end).diff(luxon.DateTime.fromJSDate(start)).toMillis());
+    console.log('result-headers:', result.headers);
+    console.log('');
+  }
+
   return result;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,13 +163,10 @@ const getGameList = async (
   config: Config,
   date: luxon.DateTime
 ): Promise<ProcessedGameList> => {
-  // Continue using legacy NHL.TV API to get the game's status.
-  const nhltvGamesPromise = getNhltvGameList(config, date);
   const nhltvCleengGamesPromise = getNhltvCleengGameList(config, date);
   const espnGamesPromise = getEspnGameList(config, date);
   const ballyGamesPromise = config.enableExperimentalProviders ? getBallyGameList(config, date) : null;
   const viaplayGamesPromise = config.enableExperimentalProviders ? getViaplayGameList(config, date) : null;
-  const nhltvGames = await nhltvGamesPromise;
   const nhltvCleengGames = await nhltvCleengGamesPromise;
   const espnGames = await espnGamesPromise;
   const ballyGames = await ballyGamesPromise ?? [];
@@ -179,7 +176,7 @@ const getGameList = async (
   const games: ProcessedGame[] = [];
   const hiddenGames: ProcessedGame[] = [];
   
-  [...nhltvGames, ...nhltvCleengGames, ...espnGames, ...ballyGames, ...viaplayGames].forEach(providerGame => {
+  [...nhltvCleengGames, ...espnGames, ...ballyGames, ...viaplayGames].forEach(providerGame => {
     const key = getGameId(providerGame.getGameDateTime(), providerGame.getAwayTeam(), providerGame.getHomeTeam());
 
     let collection = gamesById.get(key);

--- a/src/nhltvCleengApi.ts
+++ b/src/nhltvCleengApi.ts
@@ -1,7 +1,7 @@
 import axiosRestyped from "restyped-axios";
 import { idPathVariableInterceptor } from "./geekyStreamsApi";
 
-const NhltvCleengApiBaseUrl = 'https://nhl.spott2.sportradar.com/api';
+const NhltvCleengApiBaseUrl = 'https://nhltv.nhl.com/api';
 
 export interface NhltvCleengApi {
   "/v2/events": {

--- a/src/nhltvCleengProvider.ts
+++ b/src/nhltvCleengProvider.ts
@@ -18,6 +18,7 @@ import {
   ProviderTeam,
   timeXhrRequest,
   timeXhrRequestPost,
+  HttpUserAgent,
 } from "./geekyStreamsApi";
 import {
   NHLTV_CLEENG_MEDIA_STATE,
@@ -131,7 +132,12 @@ class NhltvCleengStream implements ProviderStream {
   }
 
   download(filename: string, offset: OffsetObject, streamlinkExtraOptions: string[] | undefined): void {
-    return download(filename, offset, this.stream.downloadUrl, undefined, streamlinkExtraOptions);
+    const streamlinkAuthOptions = [
+      `--http-header`,
+      "User-Agent=" + HttpUserAgent,
+    ];
+
+    return download(filename, offset, this.stream.downloadUrl, streamlinkAuthOptions, streamlinkExtraOptions);
   }
 
   getStream(): ProcessedStream {
@@ -211,16 +217,15 @@ const getNhltvCleengStreamList = async (
   });
 
   const streamAccessUrl = playerSettingsResponse.data.streamAccess;
-
-  const separator = -1 === streamAccessUrl.indexOf('?') ? '?' : '&';
-  const authenticatedStreamAccessUrl = streamAccessUrl + separator + 'authorization_code=' + mediaAuth;
-
   const streamAccessEndpoint = axiosRestyped.create<NhltvCleengStreamAccessApi>({
-    baseURL: authenticatedStreamAccessUrl,
+    baseURL: streamAccessUrl,
   });
 
   const streamAccessResponse = await timeXhrRequestPost(streamAccessEndpoint, {
     url: "",
+    headers: {
+      authorization: mediaAuth,
+    }
   });
 
   if (!streamAccessResponse.data.data?.stream) {


### PR DESCRIPTION
In essence, three changes were needed:
* changing the base uri
* provide `mediaAuth` per header instead query
* keep using the same user-agent over all the requests (or at least the ones to any `*.m3u8` uri)

I'm not happy with the changes to `timeXhrFetch` and `timeXhrRequest` but it works for now.